### PR TITLE
5단계 - Thread Pool 적용 리뷰 요청드립니다.

### DIFF
--- a/src/main/java/http/session/HttpSessionHandler.java
+++ b/src/main/java/http/session/HttpSessionHandler.java
@@ -4,15 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class HttpSessionHandler {
-    private static Map<String, HttpSession> sessions;
-
-    public static void run() {
-        new HttpSessionHandler();
-    }
-
-    private HttpSessionHandler() {
-        sessions = new HashMap<>();
-    }
+    private static Map<String, HttpSession> sessions = new HashMap<>();
 
     public static HttpSession getSession(String sessionId) {
         return sessions.get(sessionId);

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -23,7 +23,6 @@ public class WebServer {
             logger.info("Web Application Server started {} port.", port);
 
             // 클라이언트가 연결될때까지 대기한다.
-            HttpSessionHandler.run();
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
                 Thread thread = new Thread(new RequestHandler(connection));

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -2,6 +2,7 @@ package webserver;
 
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.*;
 
 import http.session.HttpSessionHandler;
 import org.slf4j.Logger;
@@ -22,12 +23,16 @@ public class WebServer {
         try (ServerSocket listenSocket = new ServerSocket(port)) {
             logger.info("Web Application Server started {} port.", port);
 
+            LinkedBlockingDeque<Runnable> queue = new LinkedBlockingDeque<>(100);
+            ExecutorService executorService = new ThreadPoolExecutor(250, 250, 0L, TimeUnit.MILLISECONDS, queue);
+
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+                executorService.execute(new RequestHandler(connection));
             }
+            executorService.shutdown();
+            executorService.awaitTermination(100, TimeUnit.SECONDS);
         }
     }
 }

--- a/src/test/java/webserver/HttpRequestTest.java
+++ b/src/test/java/webserver/HttpRequestTest.java
@@ -1,13 +1,37 @@
 package webserver;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class HttpRequestTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpRequestTest.class);
+
+    public static void main(String[] args) throws Exception {
+        ExecutorService es = Executors.newFixedThreadPool(5);
+        for (int i = 0; i < 25; i++) {
+            es.execute(() -> {
+                RestTemplate restTemplate = new RestTemplate();
+                String resourceUrl = "https://edu.nextstep.camp";
+                ResponseEntity<String> response = restTemplate.getForEntity(resourceUrl + "/c/4YUvqn9V", String.class);
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            });
+        }
+        es.shutdown();
+        es.awaitTermination(100, TimeUnit.SECONDS);
+    }
+
     @Test
     void request_resttemplate() {
         RestTemplate restTemplate = new RestTemplate();


### PR DESCRIPTION
안녕하세요!!
고유식 리뷰어님 매번 리뷰를 봐주시느라 고생이 많으십니다. 🙇‍♂️ 
스텝 4에서 피드백 주신 static을 통해 세션 객체를 메모리에 올려서 사용할 수 있었고, 세션을 따로 초기화를 할 필요가 없어서 코드가 좀 더 간결해진 것 같습니다!!

5단계는 `Executors.newFixedThreadPool()` 를 사용하지 않고 요구사항에 맞춰보려고 `ThreadPoolExecutor` 객체를 사용해서 만들었는데 이렇게 하는게 맞는걸까요..?

한가지 고민이 많았던 부분은 요구사항 2번인 서버내의 쓰레드풀 갯수 보다 많이 요청하면 어떻게 반응할 것 인가 인데 제가 하면서 느꼈던 부분은 쓰레드풀 이상의 요청이 오더라도 queue 를 통해서 다음 쓰레드 요청을 꺼내 쓰는 것 같은 느낌이 들었습니다.
이런 부분에서는 많은 요청이 와도 어느정돈 받을 수 있지만 큐의 메모리가 계속 적재가 된다면 서버에 과부화가 진행 될 것 같은 느낌이 들었습니다. 아마 이런 경우가 트래픽이 몰려서 서버가 터지는 경우가 아닐까? 라는 생각도 들었습니다.

쓰레드풀에 대해 아직 많은 지식이 없어서 잘 모르는 부분이 더 많은 것 같습니다.
5단계 리뷰 요청 드립니다!! 
감사합니다. 👍 
