### PR TITLE
Step5: Thread Pool 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,19 @@ HttpSession의 가장 중요하고 핵심이 되는 다음 5가지 메소드를 
 - void invalidate(): 현재 세션에 저장되어 있는 모든 값을 삭제
 
 세션은 클라이언트와 서버 간에 상태 값을 공유하기 위해 고유한 아이디를 활용하고, 이 고유한 아이디는 쿠키를 활용해 공유한다.
+
+### Step5: Thread Pool 적용
+
+ExecutorsTest와 HttpRequestTest 활용해 다양한 학습 테스트를 진행해 보면서 WAS의 Thead Pool 동작 원리를 이해해본다.
+
+#### 요구사항 1
+
+- Java에서 기본으로 제공하는 ThreadPoolExecutor를 활용해 ThreadPool 기능을 추가한다.
+- 최대 ThradPool의 크기는 250, 모든 Thread가 사용 중인(Busy) 상태이면 100명까지 대기 상태가 되도록 구현한다.
+  - [JAVA 쓰레드풀 분석 - newFixedThreadPool 는 어떻게 동작하는가?](https://hamait.tistory.com/937)
+  - java.util.concurrent.Executors에서 제공하는 api 활용
+
+#### 요구사항 2
+
+- Spring에서 제공하는 RestTemplate을 활용해 서버의 ThreadPool 수보다 많은 요청을 동시에 보내본다.
+- [The Guide to RestTemplate](https://www.baeldung.com/rest-template)

--- a/src/main/java/webserver/WebApplicationServer.java
+++ b/src/main/java/webserver/WebApplicationServer.java
@@ -2,18 +2,33 @@ package webserver;
 
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class WebApplicationServer {
     private static final Logger logger = LoggerFactory.getLogger(WebApplicationServer.class);
     private static final int DEFAULT_PORT = 8080;
+    private static final int THREAD_POOL_SIZE = 250;
+    private static final long KEEP_ALIVE_TIME = 0L;
+    private static final int WAITING_QUEUE_SIZE = 100;
 
     public static void main(String args[]) throws Exception {
         int port = DEFAULT_PORT;
         if (args != null && args.length > 0) {
             port = Integer.parseInt(args[0]);
         }
+
+        ExecutorService executorService = new ThreadPoolExecutor(
+                THREAD_POOL_SIZE,
+                THREAD_POOL_SIZE,
+                KEEP_ALIVE_TIME,
+                TimeUnit.MICROSECONDS,
+                new LinkedBlockingDeque<>(WAITING_QUEUE_SIZE)
+        );
 
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.
         try (ServerSocket listenSocket = new ServerSocket(port)) {
@@ -22,8 +37,7 @@ public class WebApplicationServer {
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+                executorService.execute(new RequestHandler(connection));
             }
         }
     }

--- a/src/main/java/webserver/common/HttpCookie.java
+++ b/src/main/java/webserver/common/HttpCookie.java
@@ -9,6 +9,8 @@ import webserver.common.exception.IllegalCookieException;
 import webserver.common.exception.IllegalCookieKeyException;
 
 public class HttpCookie {
+    private static final String MAP_DELIMITER = "=";
+    private static final String COOKIE_DELIMITER = "; ";
     private final Map<String, String> cookies;
 
     public HttpCookie() {
@@ -30,21 +32,20 @@ public class HttpCookie {
     }
 
     public static HttpCookie from(String cookieString) {
-        if (!cookieString.contains("=")) {
+        if (!cookieString.contains(MAP_DELIMITER)) {
             return new HttpCookie();
         }
-        String[] queries = cookieString.split("&");
+        String[] cookies = cookieString.split(COOKIE_DELIMITER);
         try {
-            return new HttpCookie(parse(queries));
+            return new HttpCookie(parse(cookies));
         } catch (ArrayIndexOutOfBoundsException exception) {
             throw new IllegalCookieException(cookieString);
         }
     }
 
     private static Map<String, String> parse(String[] cookies) {
-        String delimiter = "=";
         return Arrays.stream(cookies)
-                .map(cookie -> cookie.split(delimiter))
+                .map(cookie -> cookie.split(MAP_DELIMITER))
                 .collect(Collectors.toMap(
                         tuple -> tuple[0],
                         tuple -> tuple[1]
@@ -54,7 +55,7 @@ public class HttpCookie {
     @Override
     public String toString() {
         return cookies.entrySet().stream()
-                .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
-                .collect(Collectors.joining("&"));
+                .map(entry -> String.format("%s%s%s", entry.getKey(), MAP_DELIMITER, entry.getValue()))
+                .collect(Collectors.joining(COOKIE_DELIMITER));
     }
 }

--- a/src/main/java/webserver/common/HttpCookie.java
+++ b/src/main/java/webserver/common/HttpCookie.java
@@ -1,38 +1,60 @@
 package webserver.common;
 
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import webserver.common.exception.IllegalCookieException;
 import webserver.common.exception.IllegalCookieKeyException;
-import webserver.common.exception.IllegalQueryStringException;
-import webserver.common.exception.IllegalQueryStringKeyException;
 
 public class HttpCookie {
-    private final QueryString queryString;
+    private final Map<String, String> cookies;
 
-    private HttpCookie(QueryString queryString) {this.queryString = queryString;}
+    public HttpCookie() {
+        this.cookies = new LinkedHashMap<>();
+    }
 
-    public static HttpCookie from(String cookie) {
-        try {
-            return new HttpCookie(QueryString.from(cookie));
-        } catch (IllegalQueryStringException e) {
-            throw new IllegalCookieException(cookie);
-        }
+    private HttpCookie(Map<String, String> cookies) {
+        this.cookies = cookies;
     }
 
     public String get(String key) {
-        try {
-            return queryString.get(key);
-        } catch (IllegalQueryStringKeyException e) {
-            throw new IllegalCookieKeyException(key);
-        }
+        return Optional.ofNullable(cookies.get(key))
+                .orElseThrow(() -> new IllegalCookieKeyException(key));
     }
 
     public HttpCookie put(String key, String value) {
-        queryString.put(key, value);
+        cookies.put(key, value);
         return this;
+    }
+
+    public static HttpCookie from(String cookieString) {
+        if (!cookieString.contains("=")) {
+            return new HttpCookie();
+        }
+        String[] queries = cookieString.split("&");
+        try {
+            return new HttpCookie(parse(queries));
+        } catch (ArrayIndexOutOfBoundsException exception) {
+            throw new IllegalCookieException(cookieString);
+        }
+    }
+
+    private static Map<String, String> parse(String[] cookies) {
+        String delimiter = "=";
+        return Arrays.stream(cookies)
+                .map(cookie -> cookie.split(delimiter))
+                .collect(Collectors.toMap(
+                        tuple -> tuple[0],
+                        tuple -> tuple[1]
+                ));
     }
 
     @Override
     public String toString() {
-        return queryString.toString();
+        return cookies.entrySet().stream()
+                .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
+                .collect(Collectors.joining("&"));
     }
 }

--- a/src/main/java/webserver/request/QueryString.java
+++ b/src/main/java/webserver/request/QueryString.java
@@ -1,12 +1,12 @@
-package webserver.common;
+package webserver.request;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import webserver.common.exception.IllegalQueryStringException;
-import webserver.common.exception.IllegalQueryStringKeyException;
+import webserver.request.exception.IllegalQueryStringException;
+import webserver.request.exception.IllegalQueryStringKeyException;
 
 public class QueryString {
     private final Map<String, String> queryString;

--- a/src/main/java/webserver/request/QueryString.java
+++ b/src/main/java/webserver/request/QueryString.java
@@ -9,6 +9,8 @@ import webserver.request.exception.IllegalQueryStringException;
 import webserver.request.exception.IllegalQueryStringKeyException;
 
 public class QueryString {
+    private static final String MAP_DELIMITER = "=";
+    private static final String QUERY_DELIMITER = "&";
     private final Map<String, String> queryString;
 
     public QueryString() {
@@ -30,21 +32,20 @@ public class QueryString {
     }
 
     public static QueryString from(String queryString) {
-        if (!queryString.contains("=")) {
+        if (!queryString.contains(MAP_DELIMITER)) {
             return new QueryString();
         }
-        String[] queries = queryString.split("&");
+        String[] queries = queryString.split(QUERY_DELIMITER);
         try {
-            return new QueryString(parseQueries(queries));
+            return new QueryString(parse(queries));
         } catch (ArrayIndexOutOfBoundsException exception) {
             throw new IllegalQueryStringException(queryString);
         }
     }
 
-    private static Map<String, String> parseQueries(String[] queries) {
-        String delimiter = "=";
+    private static Map<String, String> parse(String[] queries) {
         return Arrays.stream(queries)
-                .map(query -> query.split(delimiter))
+                .map(query -> query.split(MAP_DELIMITER))
                 .collect(Collectors.toMap(
                         tuple -> tuple[0],
                         tuple -> tuple[1]
@@ -54,7 +55,7 @@ public class QueryString {
     @Override
     public String toString() {
         return queryString.entrySet().stream()
-                .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
-                .collect(Collectors.joining("&"));
+                .map(entry -> String.format("%s%s%s", entry.getKey(), MAP_DELIMITER, entry.getValue()))
+                .collect(Collectors.joining(QUERY_DELIMITER));
     }
 }

--- a/src/main/java/webserver/request/RequestBody.java
+++ b/src/main/java/webserver/request/RequestBody.java
@@ -1,8 +1,7 @@
 package webserver.request;
 
-import webserver.common.QueryString;
-import webserver.common.exception.IllegalQueryStringException;
-import webserver.common.exception.IllegalQueryStringKeyException;
+import webserver.request.exception.IllegalQueryStringException;
+import webserver.request.exception.IllegalQueryStringKeyException;
 import webserver.request.exception.IllegalRequestBodyException;
 import webserver.request.exception.IllegalRequestBodyKeyException;
 

--- a/src/main/java/webserver/request/Uri.java
+++ b/src/main/java/webserver/request/Uri.java
@@ -1,7 +1,5 @@
 package webserver.request;
 
-import webserver.common.QueryString;
-
 public class Uri {
     private final String path;
     private final QueryString queryString;

--- a/src/main/java/webserver/request/exception/IllegalQueryStringException.java
+++ b/src/main/java/webserver/request/exception/IllegalQueryStringException.java
@@ -1,4 +1,4 @@
-package webserver.common.exception;
+package webserver.request.exception;
 
 public class IllegalQueryStringException extends RuntimeException {
     private static final String MESSAGE = "%s; 부적절한 QueryString 입니다.";

--- a/src/main/java/webserver/request/exception/IllegalQueryStringKeyException.java
+++ b/src/main/java/webserver/request/exception/IllegalQueryStringKeyException.java
@@ -1,4 +1,4 @@
-package webserver.common.exception;
+package webserver.request.exception;
 
 public class IllegalQueryStringKeyException extends RuntimeException {
     private static final String MESSAGE = "%s; 부적절한 QueryString 의 키입니다.";

--- a/src/test/java/webserver/WebApplicationServerTest.java
+++ b/src/test/java/webserver/WebApplicationServerTest.java
@@ -1,0 +1,28 @@
+package webserver;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebApplicationServerTest {
+
+    @DisplayName("400 개의 요청을 보내, 서버가 정상적으로 응답해야한다.")
+    @Test
+    void send400Requests() {
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "http://localhost:8080/index.html";
+
+        List<HttpStatus> httpStatuses = IntStream.range(0, 400)
+                .parallel()
+                .mapToObj(__ -> restTemplate.getForEntity(url, String.class).getStatusCode())
+                .collect(Collectors.toList());
+
+        assertThat(httpStatuses).containsOnly(HttpStatus.OK);
+    }
+}

--- a/src/test/java/webserver/common/HttpCookieTest.java
+++ b/src/test/java/webserver/common/HttpCookieTest.java
@@ -13,7 +13,7 @@ class HttpCookieTest {
     @DisplayName("쿠키의 String 을 파싱해서 값을 가져올 수 있어야 한다.")
     @Test
     void parse() {
-        HttpCookie httpCookie = HttpCookie.from("userId=javajigi&password=password&name=JaeSung");
+        HttpCookie httpCookie = HttpCookie.from("userId=javajigi; password=password; name=JaeSung");
         assertAll(
                 () -> assertThat(httpCookie.get("userId")).isEqualTo("javajigi"),
                 () -> assertThat(httpCookie.get("password")).isEqualTo("password"),
@@ -25,7 +25,7 @@ class HttpCookieTest {
     @Test
     void illegalCookie() {
         assertThatThrownBy(
-                () -> HttpCookie.from("=&=")
+                () -> HttpCookie.from("==")
         ).isInstanceOf(IllegalCookieException.class);
     }
 
@@ -46,6 +46,6 @@ class HttpCookieTest {
                 .put("userId", "javajigi");
 
         assertThat(httpCookie.toString())
-                .isEqualTo("a=b&name=JaeSung&userId=javajigi");
+                .isEqualTo("a=b; name=JaeSung; userId=javajigi");
     }
 }

--- a/src/test/java/webserver/request/QueryStringTest.java
+++ b/src/test/java/webserver/request/QueryStringTest.java
@@ -1,9 +1,9 @@
-package webserver.common;
+package webserver.request;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import webserver.common.exception.IllegalQueryStringException;
-import webserver.common.exception.IllegalQueryStringKeyException;
+import webserver.request.exception.IllegalQueryStringException;
+import webserver.request.exception.IllegalQueryStringKeyException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/webserver/request/QueryStringTest.java
+++ b/src/test/java/webserver/request/QueryStringTest.java
@@ -26,7 +26,7 @@ class QueryStringTest {
     @Test
     void illegalQueryString() {
         assertThatThrownBy(
-                () -> QueryString.from("=&=")
+                () -> QueryString.from("==")
         ).isInstanceOf(IllegalQueryStringException.class);
     }
 


### PR DESCRIPTION
쿠키 파싱 시, queryString 의 로직을 그대로 사용하여 문제가 되던 버그를 해결했습니다.

WebServerApplication 에 ThreadPool 을 적용하고,
ThreadPool 에서 설정한 쓰레드 갯수와 큐 사이즈보다 훨씬 많은 요청을 RestTemplate 으로 보내는 테스트를 작성했습니다.

지난 PR 에서 테스트 코드에서, String 이 아니라 값객체 자체를 비교해보는 것은 어떨지에 대해서 제안을 주셨는데,
리팩토링을 진행하다보니 작업이 너무 커질 것 같아서, 미션 5의 요구사항에만 집중했습니다.